### PR TITLE
Reflect resource.id in --tag-regexps

### DIFF
--- a/awscleaner/cleaner.py
+++ b/awscleaner/cleaner.py
@@ -48,7 +48,7 @@ class AwsResourceCleaner:
         dry_run=False,
         awsweeper_file=None,
         awsweeper_args=None,
-        tag_regexps=None
+        tag_regexps=None,
     ):
         """
         Initialize the AwsResourceCleaner.
@@ -127,18 +127,25 @@ class AwsResourceCleaner:
         :rtype: number
         """
         threshold = None
-        for tkey, tvalue in resource.get("tags", {}).items():
+        tags = list(resource.get("tags", {}).items())
+        rid = resource.get("id")
+        if rid:
+            tags.append((rid, rid))
+        for tkey, tvalue in tags:
             tkey = tkey if isinstance(tkey, str) else ""
             tvalue = tvalue if isinstance(tvalue, str) else ""
             for rule, regexp in self.tag_regexps:
+                print(f"{rule} {regexp} {tkey} {tvalue}")
                 if regexp.match(tkey) or regexp.match(tvalue):
                     if threshold is None:
-                        print(f"Overriding threshold to {rule}",
-                              file=sys.stderr)
+                        print(
+                            f"Overriding threshold to {rule}", file=sys.stderr
+                        )
                         threshold = rule
                     elif threshold > rule:
-                        print(f"Overriding threshold to {rule}",
-                              file=sys.stderr)
+                        print(
+                            f"Overriding threshold to {rule}", file=sys.stderr
+                        )
                         threshold = rule
         if threshold is None:
             return default_deadline

--- a/awscleaner/cli.py
+++ b/awscleaner/cli.py
@@ -14,10 +14,10 @@
 # Copyright: Red Hat Inc. 2025
 # Author: Lukas Doktor <ldoktor@redhat.com>
 import argparse
+import re
 import shlex
 
 from .cleaner import AwsResourceCleaner
-import re
 
 
 def parse_age(value: str) -> float:
@@ -45,8 +45,9 @@ def parse_age(value: str) -> float:
 
 def parse_regexp(value: str) -> tuple:
     """Parses regexps item into tuple(seconds, compiled_regexp)"""
-    age, regexp = value.split(':', 1)
+    age, regexp = value.split(":", 1)
     return (parse_age(age), re.compile(regexp))
+
 
 def main():
     """
@@ -99,7 +100,7 @@ def main():
         "overrides age to 12h for all resources tagged with 'ci-.*' (any tag "
         " or value)",
         nargs="*",
-        type=parse_regexp
+        type=parse_regexp,
     )
 
     args = parser.parse_args()
@@ -110,7 +111,7 @@ def main():
         dry_run=args.dry_run,
         awsweeper_file=args.awsweeper_file,
         awsweeper_args=args.awsweeper_args,
-        tag_regexps=args.tag_regexps
+        tag_regexps=args.tag_regexps,
     )
     if isinstance(args.age, float):
         cleaner.THRESHOLD = args.age


### PR DESCRIPTION
we claim to delete based on name/tag, but in reality we only relied on tags. But some resources are not really tagged by the name, but they really only use the "id" property so let's include that to our list of tags to apply the "--tag-regexps" to it as well.