### PR TITLE
Ignore dependent types

### DIFF
--- a/awscleaner/cleaner.py
+++ b/awscleaner/cleaner.py
@@ -65,6 +65,9 @@ class AwsResourceCleaner:
         :param awsweeper_args: Arguments for awsweeper runner when used internally.
         :type awsweeper_args: dict, optional
         """
+        # awsweeper resource types dependent on another which can not be
+        # cleaned independently.
+        self._dependent_types = {"aws_iam_user_policy"}
         self.resources_file = resources_file
         self.cleanup_file = cleanup_file
         self.dry_run = dry_run
@@ -176,6 +179,8 @@ class AwsResourceCleaner:
             get_deadline = self._get_deadline
 
         for r in awsweeper_resources:
+            if r["type"] in self._dependent_types:
+                continue
             key = (r["type"], r["id"])
             deadline = get_deadline(r, default_deadline)
 

--- a/tests/test_cleaner.py
+++ b/tests/test_cleaner.py
@@ -48,6 +48,7 @@ def test_process_resources_complex(monkeypatch):
         {"type": "type1", "id": "id_seen_2", "key2": "value2", "__seen__": 2},
         {"type": "type1", "id": "id_seen_1", "key3": "value3", "__seen__": 1},
         {"type": "type2", "id": "id_seen_0", "key4": "value4", "__seen__": 0},
+        {"type": "aws_iam_user_policy", "id": "dependent", "__seen__": 0},
         {"type": "type1", "id": "extra_type1", "key5": "value5"},
         {"type": "awsweep_type", "id": "new_type", "key6": "value6"},
         {


### PR DESCRIPTION
awsweeper detects dependent types and lists them in the yaml output, but when one tries to delete them it reports:

    Error: invalid filter: unsupported resource type: aws_iam_user_policy

when they are not included but related users are being deleted it auto-injects them again. To avoid the failure introduce a dependent_types set to ignore them in awscleaner (they will be deleted by awsweeper based on the relevant resource).